### PR TITLE
Load pointwise module from run.pbs.

### DIFF
--- a/examples/nacaWing/run.pbs
+++ b/examples/nacaWing/run.pbs
@@ -1,6 +1,7 @@
 #!/bin/bash
 ## Required PBS Directives --------------------------------------
 #PBS -A AFVAW00262F03
+##PBS -A NAWCP25632006
 #PBS -q debug
 #PBS -l select=4:ncpus=48:mpiprocs=48
 #PBS -l walltime=01:00:00
@@ -12,6 +13,9 @@
 cd $PBS_O_WORKDIR
 source $HOME/.bashrc
 source $HOME/.profile
+
+module load pointwise/18.5R1
+
 bash clean.sh
 time python tester.py
 #time python optimizer.py


### PR DESCRIPTION
## Proposed Changes
Load Pointwise module in the run.pbs script. No longer have to load the Pointwise module from your bashrc file.
 

## PR Checklist
*Put an X by all that apply. You can fill this out after submitting the PR. These are a guide for you to know what the reviewers will be looking for in your contribution.*

- [x] My contribution generates no new compiler warnings (try with the '-Wall -Wextra -Wno-unused-parameter -Wno-empty-body' compiler flags, or simply --warnlevel=2 when using meson).
- [ ] My contribution is commented.
- [ ] I have added a test case that demonstrates my contribution, if necessary.
- [ ] I have updated appropriate documentation (Tutorials, Docs Page, config_template.cpp) , if necessary.
